### PR TITLE
Block system events from propagating if interacting with UI

### DIFF
--- a/DearImGuiInjection/Backends/ImGuiDX11.cs
+++ b/DearImGuiInjection/Backends/ImGuiDX11.cs
@@ -105,14 +105,15 @@ internal static class ImGuiDX11
 
     private static unsafe IntPtr WndProcHandler(IntPtr windowHandle, WindowMessage message, IntPtr wParam, IntPtr lParam)
     {
-        ImGuiWin32Impl.WndProcHandler(windowHandle, message, wParam, lParam);
-
         if (message == WindowMessage.WM_KEYUP && (VirtualKey)wParam == DearImGuiInjection.CursorVisibilityToggle.Get())
         {
             SaveOrRestoreCursorPosition();
 
             DearImGuiInjection.ToggleCursor();
         }
+
+        if (DearImGuiInjection.IsCursorVisible && ImGuiWin32Impl.WndProcHandler(windowHandle, message, wParam, lParam))
+            return IntPtr.Zero;
 
         return User32.CallWindowProc(_originalWindowProc, windowHandle, message, wParam, lParam);
     }

--- a/DearImGuiInjection/Backends/ImGuiDX12.cs
+++ b/DearImGuiInjection/Backends/ImGuiDX12.cs
@@ -179,14 +179,15 @@ internal static class ImGuiDX12
 
     private static unsafe IntPtr WndProcHandler(IntPtr windowHandle, WindowMessage message, IntPtr wParam, IntPtr lParam)
     {
-        ImGuiWin32Impl.WndProcHandler(windowHandle, message, wParam, lParam);
-
         if (message == WindowMessage.WM_KEYUP && (VirtualKey)wParam == DearImGuiInjection.CursorVisibilityToggle.Get())
         {
             SaveOrRestoreCursorPosition();
 
             DearImGuiInjection.ToggleCursor();
         }
+
+        if (DearImGuiInjection.IsCursorVisible && ImGuiWin32Impl.WndProcHandler(windowHandle, message, wParam, lParam))
+            return IntPtr.Zero;
 
         return User32.CallWindowProc(_originalWindowProc, windowHandle, message, wParam, lParam);
     }


### PR DESCRIPTION
System events will not be propagated if the event is targeting ImGui objects like windows, menu bars, etc.